### PR TITLE
[STYLE]: Fix lists

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -109,6 +109,9 @@
 
             /** blockquote **/
             prose-blockquote:border-s-dark-blue/50 prose-blockquote:text-slate-800/50
+
+            /** (un)ordered list **/
+            prose-ul:pl-5 prose-ol:pl-9
     }
 }
 


### PR DESCRIPTION
This will fix the wider space between the numbers/symbols, and also prevent the ordered lists to be outside the `content` container