### PR TITLE
[CHORE]: Fix toolbars

### DIFF
--- a/app/Filament/Pages/ProfilePage.php
+++ b/app/Filament/Pages/ProfilePage.php
@@ -95,10 +95,22 @@ class ProfilePage extends EditProfile
     {
         return RichEditor::make('description')
             ->label(__('Description'))
-            ->disableToolbarButtons([
-                'h1',
-                'table',
-                'attachFiles',
+            ->toolbarButtons([
+                'bold',
+                'italic',
+                'underline',
+                'strike',
+                'h2',
+                'h3',
+                'alignStart',
+                'alignCenter',
+                'alignEnd',
+                'blockquote',
+                'bulletList',
+                'orderedList',
+                'link',
+                'undo',
+                'redo',
             ])
             ->grow()
             ->helperText('This text will be display in the `About me` section of the home page');
@@ -108,9 +120,23 @@ class ProfilePage extends EditProfile
     {
         return RichEditor::make('introduction')
             ->label(__('Introduction'))
-            ->disableToolbarButtons([
-                'table',
-                'attachFiles',
+            ->toolbarButtons([
+                'bold',
+                'italic',
+                'underline',
+                'strike',
+                'h1',
+                'h2',
+                'h3',
+                'alignStart',
+                'alignCenter',
+                'alignEnd',
+                'blockquote',
+                'bulletList',
+                'orderedList',
+                'link',
+                'undo',
+                'redo',
             ])
             ->grow()
             ->helperText('This text will be display at the beginning of the home page');


### PR DESCRIPTION
For some reason the `H1` is disabled by default, and when try to only specify the missing one, the order is not the expected. That's why I decided to include the needed toolbar buttons manually.